### PR TITLE
Bump composer from 2.0.7 to 2.0.8 (#203)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ WORKDIR /opt/kimai
 RUN rm -r tests
 
 # composer base image
-FROM composer:2.0.7 AS composer
+FROM composer:2.0.8 AS composer
 
 
 ###########################


### PR DESCRIPTION
Bumps composer from 2.0.7 to 2.0.8.

Signed-off-by: dependabot[bot] <support@github.com>

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>